### PR TITLE
Containerfile: Use preprod.icr.io instead of cp.stg.icr.io

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -25,7 +25,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GO111MODULE=on \
     -o smbmetrics cmd/main.go
 
 # Use samba-server (with its smb.conf and samba utils) as base image
-FROM cp.stg.icr.io/cp/ibm-ceph/samba-server-rhel10:v9.9.2
+FROM preprod.icr.io/cp/ibm-ceph/samba-server-rhel10:v9.9.2
 COPY --from=builder /workspace/smbmetrics /bin/smbmetrics
 
 ENTRYPOINT ["/bin/smbmetrics"]


### PR DESCRIPTION
Please merge this PR only after PR : https://github.ibm.com/ceph/ceph-pipeline-configs/pull/329 has been successfully merged.